### PR TITLE
feat(migration): add migration for FS25_RealisticLivestock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ This is a modified version of the [FS25 Realistic Livestock](https://github.com/
 The current goal of this version is to keep the core parts of the mod working for my use, and do the occasional fix or improvement that feel is needed. 
 
 Feel free to use it as you see fit, but please understand that this mod is way less ambitious.
+
+
+Changelog
+v0.2.0.0:
+- Migrate savegames from Arrow-kb's Realistic Livestock to RitterMod version. To avoid conflits with original mod and other forks of it, this mod uses a different mod ID. Therefore, when you load a savegame that used the original Realistic Livestock mod, you will be prompted to migrate the data to this mod.

--- a/gui/RmMigrationDialog.xml
+++ b/gui/RmMigrationDialog.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
+    <GuiElement profile="newLayer"/>
+    <Bitmap profile="dialogFullscreenBg" id="dialogBg"/>
+    <GuiElement profile="rm_migrationDialogBg" id="dialogElement">
+        <ThreePartBitmap profile="fs25_dialogBgMiddle"/>
+        <ThreePartBitmap profile="fs25_dialogBgTop"/>
+        <ThreePartBitmap profile="fs25_dialogBgBottom"/>
+        <GuiElement profile="fs25_dialogContentContainer">
+            <Text profile="rm_migrationDialogTitle" id="titleElement" text="$l10n_rm_rl_migration_title"/>
+            <Text profile="rm_migrationDialogMessage" id="messageElement" text="$l10n_rm_rl_migration_message"/>
+
+            <GuiElement profile="rm_migrationFileListContainer">
+                <Text profile="rm_migrationFileListLabel" text="$l10n_rm_rl_migration_files_found"/>
+                <Text profile="rm_migrationFileList" id="fileListElement" text=""/>
+            </GuiElement>
+
+        </GuiElement>
+        <BoxLayout profile="fs25_dialogButtonBox">
+            <Button profile="buttonOK" text="$l10n_rm_rl_migration_continue" onClick="onClickContinue" id="continueButton"/>
+            <Button profile="buttonCancel" text="$l10n_rm_rl_migration_quit" onClick="onClickQuit" id="quitButton"/>
+        </BoxLayout>
+    </GuiElement>
+    <GUIProfiles>
+        <Profile name="rm_migrationDialogBg" extends="fs25_dialogBg">
+            <height value="400px"/>
+            <width value="700px"/>
+        </Profile>
+        <Profile name="rm_migrationDialogTitle" extends="fs25_dialogTitle" with="anchorTopCenter">
+            <position value="0px -20px"/>
+        </Profile>
+        <Profile name="rm_migrationDialogMessage" extends="fs25_dialogText" with="anchorTopCenter">
+            <position value="0px -70px"/>
+            <textMaxWidth value="600px"/>
+        </Profile>
+        <Profile name="rm_migrationFileListContainer" extends="baseReference" with="anchorTopCenter">
+            <position value="0px -160px"/>
+            <size value="600px 120px"/>
+        </Profile>
+        <Profile name="rm_migrationFileListLabel" extends="fs25_textDefault" with="anchorTopLeft">
+            <textBold value="true"/>
+            <position value="0px 0px"/>
+        </Profile>
+        <Profile name="rm_migrationFileList" extends="fs25_textDefault" with="anchorTopLeft">
+            <position value="20px -45px"/>
+            <textMaxWidth value="560px"/>
+            <textMaxNumLines value="5"/>
+        </Profile>
+    </GUIProfiles>
+</GUI>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,6 +1,6 @@
 <modDesc descVersion="105">
     <author>Ritter</author>
-    <version>0.1.0.0</version>
+    <version>0.2.0.0</version>
     <title>
         <en>Realistic Livestock - RitterMod version</en>
     </title>
@@ -10,7 +10,14 @@
 
 The current goal of this version is to keep the core parts of the mod working for my use, and do the occasional fix or improvement that feel is needed. 
 
-Feel free to use it as you see fit, but please understand that this mod is way less ambitious. ]]>
+Feel free to use it as you see fit, but please understand that this mod is way less ambitious. 
+
+
+Changelog
+v0.2.0.0:
+- Migrate savegames from Arrow-kb's Realistic Livestock to RitterMod version. To avoid conflits with original mod and other forks of it, this mod uses a different mod ID. Therefore, when you load a savegame that used the original Realistic Livestock mod, you will be prompted to migrate the data to this mod.
+
+]]>
         </en>
 
     </description>
@@ -78,6 +85,9 @@ Feel free to use it as you see fit, but please understand that this mod is way l
         <sourceFile filename="src/gui/ProfileDialog.lua"/>
         <sourceFile filename="src/gui/RL_InfoDisplayKeyValueBox.lua"/>
         <sourceFile filename="src/gui/RealisticLivestock_InGameMenuAnimalsFrame.lua"/>
+        <sourceFile filename="src/migration/RmMigrationManager.lua"/>
+        <sourceFile filename="src/migration/RmMigrationDialog.lua"/>
+        <sourceFile filename="src/migration/RmItemSystemMigration.lua"/>
         <sourceFile filename="src/handTools/specializations/HandToolHorseBrush.lua"/>
         <sourceFile filename="src/handTools/HandTool.lua"/>
         <sourceFile filename="src/handTools/HandToolSystem.lua"/>

--- a/src/FSCareerMissionInfo.lua
+++ b/src/FSCareerMissionInfo.lua
@@ -2,7 +2,8 @@ RL_FSCareerMissionInfo = {}
 
 function RL_FSCareerMissionInfo:saveToXMLFile()
     if self.xmlFile ~= nil and g_currentMission ~= nil and g_currentMission.animalSystem ~= nil then
-        g_currentMission.animalSystem:saveToXMLFile(self.savegameDirectory .. "/animalSystem.xml")
+        -- AnimalSystem:saveToXMLFile now ignores path parameter and saves to rm_RlAnimalSystem.xml
+        g_currentMission.animalSystem:saveToXMLFile(self.savegameDirectory .. "/rm_RlAnimalSystem.xml")
         RLSettings.saveToXMLFile()
     end
 end

--- a/src/RealisticLivestock_FSBaseMission.lua
+++ b/src/RealisticLivestock_FSBaseMission.lua
@@ -83,8 +83,40 @@ function RealisticLivestock_FSBaseMission:onStartMission()
     NameInputDialog.register()
     EarTagColourPickerDialog.register()
     AnimalFilterDialog.register()
+    RmMigrationDialog.register()
 
-	RLSettings.applyDefaultSettings()
+    print("FSBaseMission: onStartMission - checking migration state")
+    print("FSBaseMission: g_rmMigrationConflict = " .. tostring(g_rmMigrationConflict))
+    print("FSBaseMission: g_rmPendingMigration = " .. tostring(g_rmPendingMigration))
+    print("FSBaseMission: g_rmMigrationManager = " .. tostring(g_rmMigrationManager))
+
+    -- Handle migration conflict or pending migration (server only)
+    if self:getIsServer() then
+        print("FSBaseMission: Running on server")
+        if g_rmMigrationConflict then
+            -- Show conflict dialog and block mission
+            print("FSBaseMission: Showing conflict dialog")
+            if g_rmMigrationManager ~= nil then
+                g_rmMigrationManager:showConflictDialog()
+            else
+                print("FSBaseMission: ERROR - g_rmMigrationManager is nil!")
+            end
+        elseif g_rmPendingMigration then
+            -- Show migration dialog
+            print("FSBaseMission: Showing migration dialog")
+            if g_rmMigrationManager ~= nil then
+                g_rmMigrationManager:showMigrationDialog()
+            else
+                print("FSBaseMission: ERROR - g_rmMigrationManager is nil!")
+            end
+        else
+            print("FSBaseMission: No migration action needed")
+        end
+    else
+        print("FSBaseMission: Not running on server")
+    end
+
+    RLSettings.applyDefaultSettings()
 
     local temp = self.environment.weather.temperatureUpdater.currentMin or 20
 	local isServer = self:getIsServer() 

--- a/src/farms/FarmManager.lua
+++ b/src/farms/FarmManager.lua
@@ -3,7 +3,42 @@ RL_FarmManager = {}
 
 function RL_FarmManager:loadFromXMLFile(superFunc, path)
 
-	local returnValue = superFunc(self, path)
+    print("RL_FarmManager: loadFromXMLFile called")
+
+    -- Initialize migration manager and check for conflicts/migration needs (server only)
+    -- NOTE: Early migration (items.xml, handTools.xml) is now handled by RmItemSystemMigration
+    -- which hooks into ItemSystem.loadItems and runs BEFORE items are loaded.
+    -- Here we only check for mod conflicts and set flags for showing dialogs.
+    if g_currentMission:getIsServer() then
+        print("RL_FarmManager: Running on server, checking migration state...")
+
+        -- Create migration manager instance if not already created by RmItemSystemMigration
+        if g_rmMigrationManager == nil then
+            print("RL_FarmManager: Creating RmMigrationManager instance")
+            g_rmMigrationManager = RmMigrationManager.new()
+        end
+
+        -- Check for mod conflict (both old and new mod installed)
+        if g_rmMigrationManager:checkModConflict() then
+            -- Conflict detected - will show dialog in onStartMission
+            print("RL_FarmManager: Conflict detected!")
+            g_rmMigrationConflict = true
+        elseif not g_rmPendingMigration and g_rmMigrationManager:shouldMigrate() then
+            -- Migration needed but wasn't handled by RmItemSystemMigration (shouldn't happen normally)
+            -- This is a fallback in case ItemSystem hook didn't run
+            print("RL_FarmManager: Migration needed (fallback path)!")
+            g_rmPendingMigration = true
+        else
+            print("RL_FarmManager: No conflict detected, migration state = " .. tostring(g_rmPendingMigration))
+        end
+
+        print("RL_FarmManager: g_rmMigrationConflict = " .. tostring(g_rmMigrationConflict))
+        print("RL_FarmManager: g_rmPendingMigration = " .. tostring(g_rmPendingMigration))
+    else
+        print("RL_FarmManager: Not running on server, skipping migration check")
+    end
+
+    local returnValue = superFunc(self, path)
 
     local animalSystem = g_currentMission.animalSystem
     animalSystem:initialiseCountries()

--- a/src/handTools/HandToolSystem.lua
+++ b/src/handTools/HandToolSystem.lua
@@ -5,30 +5,58 @@ local modName = g_currentModName
 
 function RL_HandToolSystem:loadHandToolFromXML(superFunc, xmlFile, key)
 
+	print("RL_HandToolSystem: loadHandToolFromXML called for key: " .. tostring(key))
+
+	local rawFilename = xmlFile:getValue(key .. "#filename")
+	print("RL_HandToolSystem: Raw filename from XML: " .. tostring(rawFilename))
+
 	local returnValue = superFunc(self, xmlFile, key)
+	print("RL_HandToolSystem: Base game superFunc returned: " .. tostring(returnValue))
 
 	if returnValue then return true end
 
-	local filename = NetworkUtil.convertFromNetworkFilename(xmlFile:getValue(key .. "#filename"))
+	local filename = NetworkUtil.convertFromNetworkFilename(rawFilename)
+	print("RL_HandToolSystem: Converted filename: " .. tostring(filename))
+	print("RL_HandToolSystem: modName: " .. tostring(modName))
+	print("RL_HandToolSystem: Contains modName: " .. tostring(string.contains(filename, modName)))
 
-	if not string.contains(filename, modName) then return false end
+	if not string.contains(filename, modName) then
+		print("RL_HandToolSystem: Filename does not contain modName, skipping")
+		return false
+	end
 
+	print("RL_HandToolSystem: Attempting to load tempXml from: " .. tostring(filename))
 	local tempXml = XMLFile.loadIfExists("tempHandTool", filename, HandTool.xmlSchema)
-	if tempXml == nil then return false end
+	if tempXml == nil then
+		print("RL_HandToolSystem: Failed to load tempXml - file does not exist or invalid")
+		return false
+	end
 
 	local typeName = tempXml:getValue("handTool#type")
+	print("RL_HandToolSystem: typeName from straw.xml: " .. tostring(typeName))
 
 	tempXml:delete()
 
 	self.handToolsToLoad = self.handToolsToLoad + 1
 
-    local type = g_handToolTypeManager:getTypeByName(modName .. "." .. typeName)
-    local handTool = _G[type.className].new(g_currentMission:getIsServer(), g_currentMission:getIsClient())
+	local fullTypeName = modName .. "." .. typeName
+	print("RL_HandToolSystem: Looking for type: " .. tostring(fullTypeName))
 
-    handTool:setType(type)
-    handTool:setLoadCallback(self.loadHandToolFinished, self)
-    handTool:loadNonStoreItem({ ["savegameData"] = { ["xmlFile"] = xmlFile, ["key"] = key } }, filename)
+	local type = g_handToolTypeManager:getTypeByName(fullTypeName)
+	if type == nil then
+		print("RL_HandToolSystem: ERROR - type not found in handToolTypeManager!")
+		return false
+	end
 
+	print("RL_HandToolSystem: Type found, className: " .. tostring(type.className))
+
+	local handTool = _G[type.className].new(g_currentMission:getIsServer(), g_currentMission:getIsClient())
+
+	handTool:setType(type)
+	handTool:setLoadCallback(self.loadHandToolFinished, self)
+	handTool:loadNonStoreItem({ ["savegameData"] = { ["xmlFile"] = xmlFile, ["key"] = key } }, filename)
+
+	print("RL_HandToolSystem: Successfully started loading hand tool")
 	return true
 
 end

--- a/src/handTools/specializations/HandToolAIStraw.lua
+++ b/src/handTools/specializations/HandToolAIStraw.lua
@@ -1,7 +1,7 @@
 HandToolAIStraw = {}
 
 HandToolAIStraw.numHeldStraws = 0
-local specName = "spec_FS25_RealisticLivestock.aiStraw"
+local specName = "spec_FS25_RealisticLivestockRM.aiStraw"
 
 
 function HandToolAIStraw.registerFunctions(handTool)
@@ -61,15 +61,25 @@ function HandToolAIStraw:onPostLoad(savegame)
 	if savegame == nil or savegame.xmlFile == nil then return end
 
 	local xmlFile, key = savegame.xmlFile, savegame.key
-	local animalKey = key .. ".FS25_RealisticLivestock.aiStraw.animal"
 
-	spec.isEmpty = xmlFile:getBool(key .. ".FS25_RealisticLivestock.aiStraw#isEmpty", false)
-	spec.dewarUniqueId = xmlFile:getString(key .. ".FS25_RealisticLivestock.aiStraw#dewarUniqueId")
+	-- Try new namespace first, fall back to old namespace (migration support)
+	local namespace = ".FS25_RealisticLivestockRM.aiStraw"
+	if not xmlFile:hasProperty(key .. namespace) then
+		namespace = ".FS25_RealisticLivestock.aiStraw"  -- Legacy fallback
+	end
+
+	if not xmlFile:hasProperty(key .. namespace) then return end
+
+	local baseKey = key .. namespace
+	local animalKey = baseKey .. ".animal"
+
+	spec.isEmpty = xmlFile:getBool(baseKey .. "#isEmpty", false)
+	spec.dewarUniqueId = xmlFile:getString(baseKey .. "#dewarUniqueId")
 
 	if xmlFile:hasProperty(animalKey) then
 
 		local animal = {}
-		
+
 		animal.country = xmlFile:getInt(animalKey .. "#country")
 		animal.farmId = xmlFile:getString(animalKey .. "#farmId")
 		animal.uniqueId = xmlFile:getString(animalKey .. "#uniqueId")
@@ -77,7 +87,7 @@ function HandToolAIStraw:onPostLoad(savegame)
 		animal.typeIndex = xmlFile:getInt(animalKey .. "#typeIndex")
 		animal.subTypeIndex = xmlFile:getInt(animalKey .. "#subTypeIndex")
 		animal.success = xmlFile:getFloat(animalKey .. "#success")
-		
+
 		animal.genetics = {
 			["metabolism"] = xmlFile:getFloat(animalKey .. ".genetics#metabolism"),
 			["fertility"] = xmlFile:getFloat(animalKey .. ".genetics#fertility"),
@@ -85,7 +95,7 @@ function HandToolAIStraw:onPostLoad(savegame)
 			["quality"] = xmlFile:getFloat(animalKey .. ".genetics#quality"),
 			["productivity"] = xmlFile:getFloat(animalKey .. ".genetics#productivity")
 		}
-		
+
 		self.animal = animal
 
 	end

--- a/src/migration/RmItemSystemMigration.lua
+++ b/src/migration/RmItemSystemMigration.lua
@@ -1,0 +1,196 @@
+--[[
+    RmItemSystemMigration.lua
+
+    NON-DESTRUCTIVE in-memory migration for items.xml and handTools.xml.
+
+    This approach does NOT write to disk files. Instead, it patches the in-memory
+    XMLFile objects before items/hand tools are loaded. When the game saves,
+    it writes the correct (new mod) references naturally.
+
+    Benefits:
+    - User can switch back to old mod anytime (before saving) without data loss
+    - No risk of corrupting savegame files during migration
+    - Migration is "confirmed" only when user saves the game
+
+    Hooks:
+    - HandToolSystem.loadFromXMLFile: Patches handTools.xml in memory
+    - ItemSystem.loadItemsFromXML: Patches items.xml in memory (first call only)
+]]
+
+RmItemSystemMigration = {}
+
+local OLD_MOD_NAME = "FS25_RealisticLivestock"
+local NEW_MOD_NAME = "FS25_RealisticLivestockRM"
+local OLD_MOD_DIR = "$moddir$" .. OLD_MOD_NAME .. "/"
+local NEW_MOD_DIR = "$moddir$" .. NEW_MOD_NAME .. "/"
+
+-- Flags to track if we've patched each file (only patch once per session)
+local handToolsXmlPatched = false
+local itemsXmlPatched = false
+
+--[[
+    Update in-memory XMLFile with migrated filename values for handTools.xml.
+    Changes $moddir$FS25_RealisticLivestock/ to $moddir$FS25_RealisticLivestockRM/
+]]
+local function updateInMemoryHandToolsXml(xmlFile)
+    if xmlFile == nil or type(xmlFile) ~= "table" then
+        return 0
+    end
+
+    local patchedCount = 0
+    local index = 0
+
+    while true do
+        local key = string.format("handTools.handTool(%d)", index)
+        if not xmlFile:hasProperty(key) then
+            break
+        end
+
+        local filename = xmlFile:getString(key .. "#filename")
+        if filename ~= nil and string.find(filename, OLD_MOD_DIR, 1, true) ~= nil then
+            local newFilename = string.gsub(filename, OLD_MOD_DIR, NEW_MOD_DIR)
+            xmlFile:setString(key .. "#filename", newFilename)
+            print("RmItemSystemMigration: [handTools] Patched filename: " .. filename .. " -> " .. newFilename)
+            patchedCount = patchedCount + 1
+        end
+
+        index = index + 1
+    end
+
+    return patchedCount
+end
+
+--[[
+    Update in-memory XMLFile with migrated values for items.xml.
+    Changes both modName and className attributes from FS25_RealisticLivestock to FS25_RealisticLivestockRM
+]]
+local function updateInMemoryItemsXml(xmlFile)
+    if xmlFile == nil or type(xmlFile) ~= "table" then
+        return 0
+    end
+
+    local patchedCount = 0
+    local index = 0
+    local oldClassPrefix = OLD_MOD_NAME .. "."
+    local newClassPrefix = NEW_MOD_NAME .. "."
+
+    while true do
+        local key = string.format("items.item(%d)", index)
+        if not xmlFile:hasProperty(key) then
+            break
+        end
+
+        local itemPatched = false
+
+        -- Patch modName attribute
+        local modName = xmlFile:getString(key .. "#modName")
+        if modName == OLD_MOD_NAME then
+            xmlFile:setString(key .. "#modName", NEW_MOD_NAME)
+            print("RmItemSystemMigration: [items] Patched modName: " .. OLD_MOD_NAME .. " -> " .. NEW_MOD_NAME .. " for " .. key)
+            itemPatched = true
+        end
+
+        -- Patch className attribute (e.g., "FS25_RealisticLivestock.Dewar" -> "FS25_RealisticLivestockRM.Dewar")
+        local className = xmlFile:getString(key .. "#className")
+        if className ~= nil and string.find(className, oldClassPrefix, 1, true) == 1 then
+            local newClassName = newClassPrefix .. string.sub(className, #oldClassPrefix + 1)
+            xmlFile:setString(key .. "#className", newClassName)
+            print("RmItemSystemMigration: [items] Patched className: " .. className .. " -> " .. newClassName .. " for " .. key)
+            itemPatched = true
+        end
+
+        if itemPatched then
+            patchedCount = patchedCount + 1
+        end
+
+        index = index + 1
+    end
+
+    return patchedCount
+end
+
+--[[
+    Prepended function for HandToolSystem:loadFromXMLFile
+    Patches handTools.xml in memory before hand tools are loaded.
+
+    NOTE: Using dot notation because Utils.prependedFunction passes
+    the original 'self' as the first explicit parameter.
+]]
+function RmItemSystemMigration.loadHandToolsPrepend(handToolSystem, xmlFileOrFilename, asyncCallbackFunction, asyncCallbackObject, asyncCallbackArguments)
+    -- Only patch once per session
+    if handToolsXmlPatched then
+        return
+    end
+
+    print("RmItemSystemMigration: HandToolSystem:loadFromXMLFile prepend called")
+
+    -- Extract XMLFile object if it's a table
+    local xmlFileObj = nil
+    if xmlFileOrFilename ~= nil and type(xmlFileOrFilename) == "table" and xmlFileOrFilename.getFilename ~= nil then
+        xmlFileObj = xmlFileOrFilename
+        print("RmItemSystemMigration: Got XMLFile object for handTools.xml: " .. tostring(xmlFileObj:getFilename()))
+    end
+
+    -- Patch the in-memory XMLFile
+    if xmlFileObj ~= nil then
+        local patchedCount = updateInMemoryHandToolsXml(xmlFileObj)
+        handToolsXmlPatched = true
+
+        if patchedCount > 0 then
+            print(string.format("RmItemSystemMigration: Patched %d hand tools in memory (no disk write)", patchedCount))
+            g_rmPendingMigration = true
+        else
+            print("RmItemSystemMigration: No hand tools needed patching")
+        end
+    end
+end
+
+--[[
+    Prepended function for ItemSystem:loadItemsFromXML
+    Patches items.xml in memory before each item is loaded.
+
+    NOTE: This is called for EACH item, but we only patch once (first call).
+]]
+function RmItemSystemMigration.loadItemsFromXMLPrepend(itemSystem, xmlFile, key)
+    -- Only patch once per session
+    if itemsXmlPatched then
+        return
+    end
+
+    print("RmItemSystemMigration: ItemSystem:loadItemsFromXML prepend called (first time)")
+
+    -- Patch the in-memory XMLFile
+    if xmlFile ~= nil and type(xmlFile) == "table" then
+        local patchedCount = updateInMemoryItemsXml(xmlFile)
+        itemsXmlPatched = true
+
+        if patchedCount > 0 then
+            print(string.format("RmItemSystemMigration: Patched %d items in memory (no disk write)", patchedCount))
+            g_rmPendingMigration = true
+        else
+            print("RmItemSystemMigration: No items needed patching")
+        end
+    end
+end
+
+-- Hook into HandToolSystem.loadFromXMLFile - patches handTools.xml in memory
+if HandToolSystem ~= nil and HandToolSystem.loadFromXMLFile ~= nil then
+    HandToolSystem.loadFromXMLFile = Utils.prependedFunction(
+        HandToolSystem.loadFromXMLFile,
+        RmItemSystemMigration.loadHandToolsPrepend
+    )
+    print("RmItemSystemMigration: Hook registered for HandToolSystem.loadFromXMLFile")
+else
+    print("RmItemSystemMigration: WARNING - HandToolSystem.loadFromXMLFile not found!")
+end
+
+-- Hook into ItemSystem.loadItemsFromXML - patches items.xml in memory
+if ItemSystem ~= nil and ItemSystem.loadItemsFromXML ~= nil then
+    ItemSystem.loadItemsFromXML = Utils.prependedFunction(
+        ItemSystem.loadItemsFromXML,
+        RmItemSystemMigration.loadItemsFromXMLPrepend
+    )
+    print("RmItemSystemMigration: Hook registered for ItemSystem.loadItemsFromXML")
+else
+    print("RmItemSystemMigration: WARNING - ItemSystem.loadItemsFromXML not found!")
+end

--- a/src/migration/RmMigrationDialog.lua
+++ b/src/migration/RmMigrationDialog.lua
@@ -1,0 +1,97 @@
+--[[
+    RmMigrationDialog.lua
+    Dialog for prompting user about data migration from old RealisticLivestock mod
+]]
+
+RmMigrationDialog = {}
+
+local RmMigrationDialog_mt = Class(RmMigrationDialog, MessageDialog)
+local modDirectory = g_currentModDirectory
+
+-- Singleton instance
+RmMigrationDialog.INSTANCE = nil
+
+
+function RmMigrationDialog.register()
+    local dialog = RmMigrationDialog.new()
+    g_gui:loadGui(modDirectory .. "gui/RmMigrationDialog.xml", "RmMigrationDialog", dialog)
+    RmMigrationDialog.INSTANCE = dialog
+end
+
+
+function RmMigrationDialog.new(target, customMt)
+    local self = MessageDialog.new(target, customMt or RmMigrationDialog_mt)
+    self.files = {}
+    return self
+end
+
+
+function RmMigrationDialog.show(files)
+    if RmMigrationDialog.INSTANCE == nil then
+        RmMigrationDialog.register()
+    end
+
+    local dialog = RmMigrationDialog.INSTANCE
+    dialog.files = files or {}
+    dialog:setDialogType(DialogElement.TYPE_INFO)
+    dialog:updateContent()
+
+    g_gui:showDialog("RmMigrationDialog")
+end
+
+
+function RmMigrationDialog:onOpen()
+    RmMigrationDialog:superClass().onOpen(self)
+    FocusManager:setFocus(self.continueButton)
+end
+
+
+function RmMigrationDialog:onClose()
+    RmMigrationDialog:superClass().onClose(self)
+    self.files = {}
+end
+
+
+function RmMigrationDialog:onCreate()
+    RmMigrationDialog:superClass().onCreate(self)
+end
+
+
+function RmMigrationDialog:updateContent()
+    -- Update title
+    if self.titleElement ~= nil then
+        self.titleElement:setText(g_i18n:getText("rm_rl_migration_title"))
+    end
+
+    -- Update message
+    if self.messageElement ~= nil then
+        self.messageElement:setText(g_i18n:getText("rm_rl_migration_message"))
+    end
+
+    -- Update file list
+    if self.fileListElement ~= nil then
+        local fileText = ""
+        for _, file in ipairs(self.files) do
+            fileText = fileText .. "- " .. file.name .. " (" .. file.type .. ")\n"
+        end
+        self.fileListElement:setText(fileText)
+    end
+end
+
+
+--[[
+    User clicked "Continue" button
+    Close the dialog and continue loading - migration happens automatically via dual-read/new-save
+]]
+function RmMigrationDialog:onClickContinue()
+    self:close()
+end
+
+
+--[[
+    User clicked "Quit" button
+    Exit to main menu
+]]
+function RmMigrationDialog:onClickQuit()
+    doRestart(false, "")
+end

--- a/src/migration/RmMigrationManager.lua
+++ b/src/migration/RmMigrationManager.lua
@@ -1,0 +1,316 @@
+--[[
+    RmMigrationManager.lua
+    Handles migration from FS25_RealisticLivestock to FS25_RealisticLivestockRM
+
+    Migration responsibilities:
+    1. Detect old mod conflict (both mods installed)
+    2. Detect if migration is needed (old data exists, new data doesn't)
+    3. Show migration dialog to user
+
+    NON-DESTRUCTIVE MIGRATION APPROACH:
+    All migration is handled via dual-read support in the loading code:
+    - RLSettings.lua tries rm_RlSettings.xml first, falls back to rlSettings.xml
+    - RealisticLivestock_AnimalSystem.lua tries rm_RlAnimalSystem.xml first, falls back to animalSystem.xml
+    - RmItemSystemMigration.lua patches items.xml and handTools.xml in-memory
+
+    When the game saves, it writes to the NEW filenames only, effectively completing
+    the migration. The user can revert to the old mod before saving without data loss.
+
+    NOTE: No state file is used because FS25 replaces the entire savegame folder on save,
+    only preserving files written during the save callback. Migration detection relies on
+    checking whether new files (rm_RlSettings.xml) exist.
+]]
+
+RmMigrationManager = {}
+
+local RmMigrationManager_mt = Class(RmMigrationManager)
+
+-- Constants
+RmMigrationManager.OLD_MOD_NAME = "FS25_RealisticLivestock"
+RmMigrationManager.NEW_MOD_NAME = "FS25_RealisticLivestockRM"
+
+-- Old file names (for detection only - actual migration happens via dual-read)
+RmMigrationManager.OLD_FILES = {
+    "rlSettings.xml",
+    "animalSystem.xml"
+}
+
+-- Global instance
+g_rmMigrationManager = nil
+
+-- Pending migration flag (set during load, dialog shown after GUI init)
+g_rmPendingMigration = false
+g_rmMigrationConflict = false
+
+
+function RmMigrationManager.new()
+    local self = setmetatable({}, RmMigrationManager_mt)
+    self.savegameDir = nil
+    return self
+end
+
+
+function RmMigrationManager:initialize(overrideSavegameDir)
+    -- Allow override of savegame directory (used for early migration before g_currentMission is ready)
+    if overrideSavegameDir ~= nil then
+        self.savegameDir = overrideSavegameDir
+        return true
+    end
+
+    if g_currentMission == nil or g_currentMission.missionInfo == nil then
+        return false
+    end
+
+    self.savegameDir = g_currentMission.missionInfo.savegameDirectory
+    if self.savegameDir == nil then
+        return false
+    end
+
+    return true
+end
+
+
+-- Set the savegame directory directly (for early migration)
+function RmMigrationManager:setSavegameDir(savegameDir)
+    self.savegameDir = savegameDir
+end
+
+
+--[[
+    Check if the old RealisticLivestock mod is also ENABLED and LOADED
+    If both mods are loaded, this causes conflicts
+    Returns true if conflict detected (old mod is enabled)
+
+    Note: g_modNameToDirectory contains ALL mods in the folder (enabled or not)
+          g_modIsLoaded contains only mods that are actually enabled and loaded
+]]
+function RmMigrationManager:checkModConflict()
+    print("RmMigrationManager: Checking for mod conflict...")
+    print("RmMigrationManager: Looking for mod: " .. tostring(RmMigrationManager.OLD_MOD_NAME))
+
+    -- Debug: print enabled/loaded mods
+    if g_modIsLoaded ~= nil then
+        print("RmMigrationManager: Enabled mods (g_modIsLoaded):")
+        for modName, isLoaded in pairs(g_modIsLoaded) do
+            if isLoaded then
+                print("  - " .. tostring(modName))
+            end
+        end
+    else
+        print("RmMigrationManager: g_modIsLoaded is nil!")
+    end
+
+    -- Check if old mod is ENABLED (not just present in folder)
+    -- g_modIsLoaded[modName] returns true only if the mod is enabled and loaded
+    local oldModLoaded = g_modIsLoaded ~= nil and g_modIsLoaded[RmMigrationManager.OLD_MOD_NAME] == true
+
+    print("RmMigrationManager: Old mod enabled and loaded: " .. tostring(oldModLoaded))
+
+    if oldModLoaded then
+        g_rmMigrationConflict = true
+        return true
+    end
+
+    return false
+end
+
+
+--[[
+    Show conflict dialog and block mission loading.
+    Uses a short timer delay to ensure the dialog is shown after the game
+    has fully transitioned to gameplay state, similar to how Courseplay
+    shows its version dialog.
+]]
+function RmMigrationManager:showConflictDialog()
+    print("RmMigrationManager: showConflictDialog called, scheduling dialog...")
+
+    -- Use a short delay to ensure the game has fully entered gameplay state
+    -- before showing the dialog. This ensures the dialog properly overlays
+    -- on top of the gameplay screen rather than getting lost during the
+    -- loading-to-gameplay transition.
+    Timer.createOneshot(100, function()
+        print("RmMigrationManager: Timer fired, showing conflict dialog now")
+
+        local title = g_i18n:getText("rm_rl_conflict_title")
+        local message = g_i18n:getText("rm_rl_conflict_message")
+        local text = title .. "\n\n" .. message
+
+        InfoDialog.show(text, function()
+            print("RmMigrationManager: User acknowledged conflict, restarting game")
+            -- Restart the game so user can disable the conflicting mod
+            doRestart(false, "")
+        end, self)
+    end)
+end
+
+
+--[[
+    Check if migration is needed
+    Returns true if:
+    - Old data files exist AND
+    - New data files don't exist
+]]
+function RmMigrationManager:shouldMigrate()
+    if not self:initialize() then
+        return false
+    end
+
+    -- Check for old data
+    local hasOldSettings = fileExists(self.savegameDir .. "/rlSettings.xml")
+    local hasOldAnimalSystem = fileExists(self.savegameDir .. "/animalSystem.xml")
+    local hasOld = hasOldSettings or hasOldAnimalSystem
+
+    if not hasOld then
+        return false
+    end
+
+    -- Check for new data (if exists, no migration needed - user already saved with new mod)
+    local hasNewSettings = fileExists(self.savegameDir .. "/rm_RlSettings.xml")
+    if hasNewSettings then
+        return false
+    end
+
+    return true
+end
+
+
+--[[
+    Get list of old data files that exist
+    Returns table with file info for display in migration dialog
+]]
+function RmMigrationManager:getOldDataFiles()
+    if not self:initialize() then
+        return {}
+    end
+
+    local files = {}
+
+    if fileExists(self.savegameDir .. "/rlSettings.xml") then
+        table.insert(files, { name = "rlSettings.xml", type = "Settings" })
+    end
+
+    if fileExists(self.savegameDir .. "/animalSystem.xml") then
+        table.insert(files, { name = "animalSystem.xml", type = "Animal System" })
+    end
+
+    -- Check for Dewar items in items.xml (modName="FS25_RealisticLivestock")
+    if self:hasOldItemsData() then
+        table.insert(files, { name = "items.xml", type = "Dewars" })
+    end
+
+    -- Check for AI Straw hand tools in handTools.xml (filename contains $moddir$FS25_RealisticLivestock/)
+    if self:hasOldHandToolsData() then
+        table.insert(files, { name = "handTools.xml", type = "AI Straw Hand Tools" })
+    end
+
+    -- Check for HandToolAIStraw namespace data in items.xml (legacy namespace migration)
+    local itemsPath = self.savegameDir .. "/items.xml"
+    if fileExists(itemsPath) then
+        local itemsXml = XMLFile.loadIfExists("items", itemsPath)
+        if itemsXml ~= nil then
+            local hasOldNamespace = false
+            itemsXml:iterate("items.item", function(_, key)
+                local oldKey = key .. ".FS25_RealisticLivestock.aiStraw"
+                if itemsXml:hasProperty(oldKey) then
+                    hasOldNamespace = true
+                    return false -- Stop iteration
+                end
+            end)
+            itemsXml:delete()
+
+            if hasOldNamespace then
+                table.insert(files, { name = "items.xml (namespace)", type = "AI Straw Data" })
+            end
+        end
+    end
+
+    return files
+end
+
+
+--[[
+    Check if items.xml has old mod references (className/modName)
+    This is different from namespace migration - this is about the item registration itself
+]]
+function RmMigrationManager:hasOldItemsData()
+    if not self:initialize() then
+        return false
+    end
+
+    local itemsPath = self.savegameDir .. "/items.xml"
+    if not fileExists(itemsPath) then
+        return false
+    end
+
+    local xmlFile = XMLFile.loadIfExists("items_check", itemsPath)
+    if xmlFile == nil then
+        return false
+    end
+
+    local hasOldData = false
+    xmlFile:iterate("items.item", function(_, key)
+        local modName = xmlFile:getString(key .. "#modName")
+        if modName == RmMigrationManager.OLD_MOD_NAME then
+            hasOldData = true
+            return false -- Stop iteration
+        end
+    end)
+
+    xmlFile:delete()
+    return hasOldData
+end
+
+
+--[[
+    Check if handTools.xml has old mod references in filename attribute
+    Note: Hand tools don't have a modName attribute, they use filename with $moddir$ModName/ path
+]]
+function RmMigrationManager:hasOldHandToolsData()
+    if not self:initialize() then
+        return false
+    end
+
+    local handToolsPath = self.savegameDir .. "/handTools.xml"
+    if not fileExists(handToolsPath) then
+        return false
+    end
+
+    local xmlFile = XMLFile.loadIfExists("handTools_check", handToolsPath)
+    if xmlFile == nil then
+        return false
+    end
+
+    local hasOldData = false
+    local oldModPath = "$moddir$" .. RmMigrationManager.OLD_MOD_NAME .. "/"
+
+    xmlFile:iterate("handTools.handTool", function(_, key)
+        local filename = xmlFile:getString(key .. "#filename")
+        if filename ~= nil and string.find(filename, oldModPath, 1, true) then
+            hasOldData = true
+            return false -- Stop iteration
+        end
+    end)
+
+    xmlFile:delete()
+    return hasOldData
+end
+
+
+--[[
+    Show migration dialog to user.
+    Uses a short timer delay for consistency with showConflictDialog.
+]]
+function RmMigrationManager:showMigrationDialog()
+    print("RmMigrationManager: showMigrationDialog called, scheduling dialog...")
+
+    Timer.createOneshot(100, function()
+        print("RmMigrationManager: Timer fired, showing migration dialog now")
+
+        if RmMigrationDialog ~= nil and RmMigrationDialog.show ~= nil then
+            local files = self:getOldDataFiles()
+            RmMigrationDialog.show(files)
+        else
+            print("RmMigrationManager: ERROR - RmMigrationDialog not available")
+        end
+    end)
+end

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1,7 +1,7 @@
 <l10n>
 	<texts>
 		<!-- COWS -->
-		
+
 		<text name="fillType_bull" text="Bull"/>
 		<text name="fillType_bull_swiss_brown" text="Brown-Swiss Bull"/>
 		<text name="fillType_bull_holstein" text="Holstein Bull"/>
@@ -18,7 +18,7 @@
 		<text name="fillType_bull_waterbuffalo" text="Water Buffalo Bull"/>
 
 		<!-- PIGS -->
-		
+
 		<text name="fillType_boar" text="Boar"/>
 		<text name="fillType_boar_landrace" text="Landrace Boar"/>
 		<text name="fillType_boar_black_pied" text="Black-Pied Boar"/>
@@ -28,7 +28,7 @@
 		<text name="animal_descriptionBoarYoung" text="This is a male piglet."/>
 
 		<!-- SHEEP -->
-		
+
 		<text name="fillType_ram" text="Ram"/>
 		<text name="fillType_ram_landrace" text="Landrace of Bentheim Ram"/>
 		<text name="fillType_ram_steinschaf" text="Steinschaf Ram"/>
@@ -41,9 +41,9 @@
 		<!-- GOATS -->
 
 		<text name="fillType_ram_goat" text="Goat Ram"/>
-		
+
 		<!-- HORSES -->
-		
+
 		<text name="fillType_stallion" text="Stallion"/>
 		<text name="fillType_stallion_gray" text="Gray Stallion"/>
 		<text name="fillType_stallion_pinto" text="Pinto Stallion"/>
@@ -58,49 +58,49 @@
 		<text name="animal_descriptionStallionReproduction" text="Stallions that are healthy and older than 36 months can reproduce."/>
 
 
-        <!-- UI -->
+		<!-- UI -->
 
-		
-        <text name="input_VisualAnimalsDialog" text="Change Visual Animals Amount"/>
-        <text name="rl_button_apply" text="Apply"/>
-        <text name="rl_button_confirm" text="Confirm"/>
-        <text name="rl_button_recommended" text="Recommended"/>
-        <text name="rl_button_cancel" text="Cancel"/>
-        <text name="rl_button_random" text="Random"/>
-        <text name="rl_dialog_title" text="Set Maximum Number of Visual Animals"/>
 
-        <text name="rl_ui_unhealthy" text="Too unhealthy"/>
-        <text name="rl_ui_unhealthyBracketed" text="No (too unhealthy)"/>
-        <text name="rl_ui_noMaleAnimal" text="No suitable male animal"/>
-        <text name="rl_ui_noMaleAnimalBracketed" text="No (no suitable male animal)"/>
-        <text name="rl_ui_recoveringLastBirth" text="Recovering from last birth"/>
-        <text name="rl_ui_recoveringLastBirthBracketed" text="No (recovering from last birth)"/>
-        <text name="rl_ui_tooYoung" text="Too young"/>
-        <text name="rl_ui_tooYoungBracketed" text="No (too young)"/>
-        <text name="rl_ui_pregnant" text="Pregnant"/>
-        <text name="rl_ui_lactating" text="Lactating"/>
-        <text name="rl_ui_canReproduce" text="Can reproduce"/>
-        <text name="rl_ui_impregnatedBy" text="Impregnated by"/>
-        <text name="rl_ui_unknown" text="Unknown"/>
-        <text name="rl_ui_yes" text="Yes"/>
-        <text name="rl_ui_no" text="No"/>
-        <text name="rl_ui_mother" text="Mother"/>
-        <text name="rl_ui_father" text="Father"/>
-        <text name="rl_ui_uniqueId" text="Unique ID"/>
-        <text name="rl_ui_farmId" text="Farm ID"/>
-        <text name="rl_ui_gender" text="Gender"/>
-        <text name="rl_ui_male" text="Male"/>
-        <text name="rl_ui_female" text="Female"/>
-        <text name="rl_ui_weight" text="Weight"/>
+		<text name="input_VisualAnimalsDialog" text="Change Visual Animals Amount"/>
+		<text name="rl_button_apply" text="Apply"/>
+		<text name="rl_button_confirm" text="Confirm"/>
+		<text name="rl_button_recommended" text="Recommended"/>
+		<text name="rl_button_cancel" text="Cancel"/>
+		<text name="rl_button_random" text="Random"/>
+		<text name="rl_dialog_title" text="Set Maximum Number of Visual Animals"/>
+
+		<text name="rl_ui_unhealthy" text="Too unhealthy"/>
+		<text name="rl_ui_unhealthyBracketed" text="No (too unhealthy)"/>
+		<text name="rl_ui_noMaleAnimal" text="No suitable male animal"/>
+		<text name="rl_ui_noMaleAnimalBracketed" text="No (no suitable male animal)"/>
+		<text name="rl_ui_recoveringLastBirth" text="Recovering from last birth"/>
+		<text name="rl_ui_recoveringLastBirthBracketed" text="No (recovering from last birth)"/>
+		<text name="rl_ui_tooYoung" text="Too young"/>
+		<text name="rl_ui_tooYoungBracketed" text="No (too young)"/>
+		<text name="rl_ui_pregnant" text="Pregnant"/>
+		<text name="rl_ui_lactating" text="Lactating"/>
+		<text name="rl_ui_canReproduce" text="Can reproduce"/>
+		<text name="rl_ui_impregnatedBy" text="Impregnated by"/>
+		<text name="rl_ui_unknown" text="Unknown"/>
+		<text name="rl_ui_yes" text="Yes"/>
+		<text name="rl_ui_no" text="No"/>
+		<text name="rl_ui_mother" text="Mother"/>
+		<text name="rl_ui_father" text="Father"/>
+		<text name="rl_ui_uniqueId" text="Unique ID"/>
+		<text name="rl_ui_farmId" text="Farm ID"/>
+		<text name="rl_ui_gender" text="Gender"/>
+		<text name="rl_ui_male" text="Male"/>
+		<text name="rl_ui_female" text="Female"/>
+		<text name="rl_ui_weight" text="Weight"/>
 		<text name="rl_ui_targetWeight" text="Target weight"/>
-        <text name="rl_ui_value" text="Value"/>
-        <text name="rl_ui_valuePerKilo" text="Value per kg"/>
+		<text name="rl_ui_value" text="Value"/>
+		<text name="rl_ui_valuePerKilo" text="Value per kg"/>
 		<text name="rl_ui_genetics" text="Genetics"/>
 		<text name="rl_ui_overall" text="Overall"/>
 		<text name="rl_ui_rename" text="Change Name"/>
 		<text name="rl_ui_cantFindAnimal" text="Could not find animal"/>
 		<text name="rl_ui_maleNumImpregnatable" text="Impregnatable animals in pen"/>
-		
+
 		<text name="rl_ui_breederQuality" text="Breeder Quality"/>
 		<text name="rl_ui_birthday" text="Birthday"/>
 		<text name="rl_ui_pregnancyExpected" text="Expected"/>
@@ -140,7 +140,7 @@
 		<text name="rl_ui_genetics_good" text="Good"/>
 		<text name="rl_ui_genetics_veryGood" text="Very good"/>
 		<text name="rl_ui_genetics_extremelyGood" text="Extremely good"/>
-		
+
 		<text name="rl_ui_buySelected" text="Buy selected"/>
 		<text name="rl_ui_sellSelected" text="Sell selected"/>
 		<text name="rl_ui_moveSelected" text="Move selected"/>
@@ -168,7 +168,7 @@
 		<text name="rl_ui_output_pallets_goatMilk" text="Goat milk"/>
 		<text name="rl_ui_amountPerDay" text="%.0fL / day" tag="format"/>
 		<text name="rl_ui_feePerMonth" text="%s / month" tag="format"/>
-		
+
 		<text name="rl_ui_animalType" text="Type"/>
 		<text name="rl_ui_amountMonitored" text="Monitored"/>
 		<text name="rl_ui_production" text="Products"/>
@@ -184,7 +184,7 @@
 		<text name="rl_ui_textColour" text="Text Colour"/>
 		<text name="rl_ui_textHue" text="Text Hue"/>
 		<text name="rl_ui_textRgb" text="Text RGB"/>
-		
+
 		<text name="rl_ui_formatMonths" text="%s months"/>
 		<text name="rl_ui_formatMonth" text="%s month"/>
 		<text name="rl_ui_notPregnant" text="Not Pregnant"/>
@@ -196,12 +196,12 @@
 		<text name="rl_ui_filters" text="Filters"/>
 		<text name="rl_ui_doesntHaveName" text="No Name"/>
 		<text name="rl_ui_doesHaveName" text="Has Name"/>
-		
-		
-		
+
+
+
 		<text name="rl_ui_castrated" text="Castrated"/>
 		<text name="rl_ui_castrate" text="Castrate"/>
-		
+
 		<text name="rl_ui_importance" text="Importance"/>
 		<text name="rl_ui_type" text="Type"/>
 		<text name="rl_ui_date" text="Date"/>
@@ -264,12 +264,12 @@
 		<text name="rl_ui_load" text="Load"/>
 		<text name="rl_ui_saveProfile" text="Save Profile"/>
 		<text name="rl_ui_loadProfile" text="Load Profile"/>
-		
+
 		<text name="rl_ui_healthy" text="Healthy"/>
 		<text name="rl_ui_hasDisease" text="Has Disease"/>
 		<text name="rl_ui_diseasedAnimals" text="Diseased Animals"/>
-		
-		
+
+
 		<text name="rl_insemination_male" text="Only females can be artificially inseminated"/>
 		<text name="rl_insemination_pregnant" text="This animal is already pregnant"/>
 		<text name="rl_insemination_animalType" text="Animal must be of the same species as the father"/>
@@ -277,61 +277,61 @@
 		<text name="rl_insemination_recovering" text="This animal is still recovering from its previous pregnancy"/>
 		<text name="rl_insemination_father" text="Inbreeding is not permitted"/>
 		<text name="rl_insemination_young" text="This animal is too young to be artificially inseminated"/>
-		
-		
+
+
 		<text name="rl_mark_aiManager_sell" text="Herdsman marked for selling"/>
 		<text name="rl_mark_aiManager_castrate" text="Herdsman marked for castrating"/>
 		<text name="rl_mark_aiManager_disease" text="Herdsman marked for treating"/>
 		<text name="rl_mark_aiManager_ai" text="Herdsman marked for artificial insemination"/>
 		<text name="rl_mark_player" text="Marked by player"/>
-		
-		
+
+
 		<!-- AI - BUYING -->
-		
-		
+
+
 		<text name="rl_ui_herdsmanTooltip_buy_enabled_1" text="The herdsman will not purchase animals"/>
 		<text name="rl_ui_herdsmanTooltip_buy_enabled_2" text="The herdsman will purchase animals"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_budget|type_1" text="Purchasing budget is a fixed amount"/>
 		<text name="rl_ui_herdsmanTooltip_buy_budget|type_2" text="Purchasing budget is a percentage of your farm's money"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_budget|fixed" text="The herdsman will spend up to %s per day"/>
 		<text name="rl_ui_herdsmanTooltip_buy_budget|percentage" text="The herdsman will spend up to %s of your farm's money per day"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_maxAnimals" text="The herdsman will buy up to %s animals per day"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_breed" text="The herdsman will only buy %s animals"/>
 		<text name="rl_ui_herdsmanTooltip_buy_breed_any" text="The herdsman will buy any breed"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_diseases_1" text="The herdsman will only purchase animals without any diseases"/>
 		<text name="rl_ui_herdsmanTooltip_buy_diseases_2" text="The herdsman will purchase animals regardless of diseases"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_gender_1" text="The herdsman will only purchase female animals"/>
 		<text name="rl_ui_herdsmanTooltip_buy_gender_2" text="The herdsman will purchase female and male animals"/>
 		<text name="rl_ui_herdsmanTooltip_buy_gender_3" text="The herdsman will only purchase male animals"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_age_equal" text="The herdsman will only purchase animals that are %s old"/>
 		<text name="rl_ui_herdsmanTooltip_buy_age_range" text="The herdsman will only purchase animals that are between %s and %s old"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_quality_equal" text="The herdsman will only purchase animals with %s quality"/>
 		<text name="rl_ui_herdsmanTooltip_buy_quality_range" text="The herdsman will only purchase animals with quality between %s and %s"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_fertility_equal" text="The herdsman will only purchase animals with %s fertility"/>
 		<text name="rl_ui_herdsmanTooltip_buy_fertility_range" text="The herdsman will only purchase animals with fertility between %s and %s"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_health_equal" text="The herdsman will only purchase animals with %s health"/>
 		<text name="rl_ui_herdsmanTooltip_buy_health_range" text="The herdsman will only purchase animals with health between %s and %s"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_productivity_equal" text="The herdsman will only purchase animals with %s productivity"/>
 		<text name="rl_ui_herdsmanTooltip_buy_productivity_range" text="The herdsman will only purchase animals with productivity between %s and %s"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_buy_metabolism_equal" text="The herdsman will only purchase animals with %s metabolism"/>
 		<text name="rl_ui_herdsmanTooltip_buy_metabolism_range" text="The herdsman will only purchase animals with metabolism between %s and %s"/>
-		
+
 
 		<!-- AI - SELLING -->
-		
-		
+
+
 		<text name="rl_ui_herdsmanTooltip_sell_enabled_1" text="The herdsman will not sell animals"/>
 		<text name="rl_ui_herdsmanTooltip_sell_enabled_2" text="The herdsman will sell animals"/>
 
@@ -342,32 +342,32 @@
 
 		<text name="rl_ui_herdsmanTooltip_sell_diseasesSecondary_1" text="The herdsman will sell animals regardless of diseases"/>
 		<text name="rl_ui_herdsmanTooltip_sell_diseasesSecondary_2" text="The herdsman will only sell animals with a disease"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_sell_gender_1" text="The herdsman will only sell female animals"/>
 		<text name="rl_ui_herdsmanTooltip_sell_gender_2" text="The herdsman will sell female and male animals"/>
 		<text name="rl_ui_herdsmanTooltip_sell_gender_3" text="The herdsman will only sell male animals"/>
 
 		<text name="rl_ui_herdsmanTooltip_sell_age_equal" text="The herdsman will only sell animals that are %s old"/>
 		<text name="rl_ui_herdsmanTooltip_sell_age_range" text="The herdsman will only sell animals that are between %s and %s old"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_sell_quality_equal" text="The herdsman will only sell animals with %s quality"/>
 		<text name="rl_ui_herdsmanTooltip_sell_quality_range" text="The herdsman will only sell animals with quality between %s and %s"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_sell_fertility_equal" text="The herdsman will only sell animals with %s fertility"/>
 		<text name="rl_ui_herdsmanTooltip_sell_fertility_range" text="The herdsman will only sell animals with fertility between %s and %s"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_sell_health_equal" text="The herdsman will only sell animals with %s health"/>
 		<text name="rl_ui_herdsmanTooltip_sell_health_range" text="The herdsman will only sell animals with health between %s and %s"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_sell_productivity_equal" text="The herdsman will only sell animals with %s productivity"/>
 		<text name="rl_ui_herdsmanTooltip_sell_productivity_range" text="The herdsman will only sell animals with productivity between %s and %s"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_sell_metabolism_equal" text="The herdsman will only sell animals with %s metabolism"/>
 		<text name="rl_ui_herdsmanTooltip_sell_metabolism_range" text="The herdsman will only sell animals with metabolism between %s and %s"/>
-		
+
 
 		<!-- AI - CASTRATING -->
-		
+
 
 		<text name="rl_ui_herdsmanTooltip_castrate_enabled_1" text="The herdsman will not castrate animals"/>
 		<text name="rl_ui_herdsmanTooltip_castrate_enabled_2" text="The herdsman will castrate animals"/>
@@ -395,14 +395,14 @@
 
 		<text name="rl_ui_herdsmanTooltip_castrate_metabolism_equal" text="The herdsman will only castrate animals with %s metabolism"/>
 		<text name="rl_ui_herdsmanTooltip_castrate_metabolism_range" text="The herdsman will only castrate animals with metabolism between %s and %s"/>
-		
+
 
 		<!-- AI - NAMING -->
-		
+
 
 		<text name="rl_ui_herdsmanTooltip_naming_enabled_1" text="The herdsman will not name animals"/>
 		<text name="rl_ui_herdsmanTooltip_naming_enabled_2" text="The herdsman will name animals"/>
-		
+
 		<text name="rl_ui_herdsmanTooltip_naming_convention_1" text="The herdsman will name animals randomly"/>
 		<text name="rl_ui_herdsmanTooltip_naming_convention_2" text="The herdsman will name animals alphabetically"/>
 
@@ -447,7 +447,7 @@
 
 
 		<!--  SETTINGS  -->
-		
+
 
 		<text name="rl_settings" text="Realistic Livestock"/>
 
@@ -470,15 +470,15 @@
 
 		<text name="rl_settings_maxDealerAnimals_label" text="Max Dealer Animals"/>
 		<text name="rl_settings_maxDealerAnimals_tooltip" text="Change the maximum number of animals the animal dealer will have in stock per animal type"/>
-		
+
 		<text name="rl_settings_resetDealer_label" text="Reset Animal Dealer"/>
 		<text name="rl_settings_resetDealer_tooltip" text="Remove all the dealer's animals and replenish the stock with new animals"/>
 		<text name="rl_settings_resetDealer_text" text="Reset Animal Dealer"/>
-		
+
 		<text name="rl_settings_tagColour_label" text="Change Tag Colour"/>
 		<text name="rl_settings_tagColour_tooltip" text="Change the colour of ear tags"/>
 		<text name="rl_settings_tagColour_text" text="Change Tag Colour"/>
-		
+
 		<text name="rl_settings_exportCSV_label" text="Export To CSV"/>
 		<text name="rl_settings_exportCSV_tooltip" text="Export stats to CSV"/>
 		<text name="rl_settings_exportCSV_text" text="Export To CSV"/>
@@ -500,9 +500,9 @@
 		<text name="rl_settings_animalsXML_label" text="Set Animals XML Path"/>
 		<text name="rl_settings_animalsXML_tooltip" text="Set path to a custom animals XML file"/>
 		<text name="rl_settings_animalsXML_text" text="Set Animals XML Path"/>
-		
-		
-		
+
+
+
 		<!--  HELP  -->
 
 
@@ -510,7 +510,7 @@
 		<text name="rl_help_monitors_1" text="In order to see the majority of an animal's statistics, you need to apply a monitoring tag to it, which can be done through the animal menu (where you buy and sell animals). Monitoring tags are also visually shown on the animal, on their left ear next to their ID tag."/>
 		<text name="rl_help_monitors_2" text="Monitoring tags will result in important information being shown to you, including health, weight, lactation, production, and straw, food and water requirements."/>
 		<text name="rl_help_monitors_3" text="Applying a tag to an animal will cost you a small monthly subscription based on the animal's species. If you choose to remove the tag, the tag will be removed at the start of the next month."/>
-		
+
 		<text name="rl_help_pregnancy_title" text="Pregnancy"/>
 		<text name="rl_help_pregnancy_1" text="Female animals all require at least 1 male animal in order to potentially become pregnant. Both animals must be of the correct age and health, and must be from the same species. Breeding between different breeds (eg: holstein cow and angus bull) is allowed."/>
 		<text name="rl_help_pregnancy_2" text="Inbreeding is not allowed. If a male and a female are directly related, they will not breed together."/>
@@ -522,11 +522,11 @@
 		<text name="rl_help_production_1" text="Cows of any breed will only begin to produce milk after giving birth. Once she has given birth, the cow will produce milk exponentially for 3 months, then her production will slowly drop for the next 6 months. 10 months after pregnancy, the cow will stop producing milk until her next pregnancy."/>
 		<text name="rl_help_production_2" text="Sheep will produce wool in warm months. In cold months, under 12C, they will not produce wool."/>
 		<text name="rl_help_production_3" text="Milk, wool and egg production is further affected by the animal's genetics. An animal with good production genetics will produce more, whereas animal with bad genetics wont produce much at all."/>
-		
+
 		<text name="rl_help_weight_title" text="Weight"/>
 		<text name="rl_help_weight_1" text="Animals have a certain weight that which is affected by how much they eat and drink. Every species and breed has its own average weight which affects the weight of each animal."/>
 		<text name="rl_help_weight_2" text="Weight increases the value of the animal, and a low weight affects its chance of being removed each month."/>
-		
+
 		<text name="rl_help_genetics_title" text="Genetics"/>
 		<text name="rl_help_genetics_1" text="Each animal has 4 different genetic values; metabolism, fertility, health and quality. Genetics are mixed between the mother and father and then passed down to their children."/>
 		<text name="rl_help_genetics_2" text="Metabolism affects the animal's ability to convert food into weight, and affects the amount it eats."/>
@@ -538,8 +538,8 @@
 
 
 		<!--  DISEASES  -->
-		
-	
+
+
 		<text name="rl_ui_immune" text="Immune"/>
 		<text name="rl_ui_startTreatment" text="Start Treatment"/>
 		<text name="rl_ui_resumeTreatment" text="Resume Treatment"/>
@@ -548,22 +548,22 @@
 		<text name="rl_ui_beingTreated" text="Being treated"/>
 		<text name="rl_ui_notTreated" text="Not treated"/>
 		<text name="rl_ui_carrier" text="Carrier"/>
-		
+
 		<text name="rl_diseases" text="Diseases"/>
 		<text name="rl_disease" text="Disease"/>
-		
+
 		<text name="rl_disease_mastitis" text="Mastitis"/>
-		
+
 		<text name="rl_disease_cvm" text="CVM"/>
-		
+
 		<text name="rl_disease_footAndMouth" text="Foot and Mouth"/>
-		
+
 		<text name="rl_disease_ped" text="Porcine Epidemic Diarrhoea"/>
-		
+
 		<text name="rl_disease_avianFlu" text="Avian Influenza"/>
-		
-		
-		
+
+
+
 		<!--  MESSAGES  -->
 
 
@@ -575,7 +575,7 @@
 		<text name="rl_messageTitle_movement" text="Movement"/>
 		<text name="rl_messageTitle_aiManager" text="Herdsman"/>
 		<text name="rl_messageTitle_insemination" text="Artificial Insemination"/>
-		
+
 		<text name="rl_message_pregnancySingle" text="Gave birth to 1 baby"/>
 		<text name="rl_message_pregnancyMultiple" text="Gave birth to %s babies"/>
 		<text name="rl_message_pregnancySold" text="%s babies were sold for %s due to overcrowding"/>
@@ -619,9 +619,9 @@
 		<text name="rl_message_aiManager_mark_ai_multiple" text="Herdsman marked %s animals for AI"/>
 		<text name="rl_message_aiManager_ai_single" text="Herdsman inseminated 1 animal"/>
 		<text name="rl_message_aiManager_ai_multiple" text="Herdsman inseminated %s animals"/>
-		
-		
-		
+
+
+
 		<!--  DEATHS  -->
 
 
@@ -635,7 +635,19 @@
 		<text name="rl_ui_dependencies_missing" text="RealisticLivestock requires the following dependencies:"/>
 		<text name="rl_ui_dependency_missing_notInstalled" text="- %s (Not Installed)"/>
 		<text name="rl_ui_dependency_missing_installed" text="- %s (Installed: %s, Minimum Required: %s)"/>
-		
-		
+
+
+		<!-- MIGRATION -->
+
+		<text name="rm_rl_conflict_title" text="Mod Conflict Detected"/>
+		<text name="rm_rl_conflict_message" text="Both 'Realistic Livestock' and 'Realistic Livestock - RitterMod version' are enabled. Please disable 'Realistic Livestock' (FS25_RealisticLivestock) to continue. The RitterMod version will migrate your saved data."/>
+
+		<text name="rm_rl_migration_title" text="Data Migration Notice"/>
+		<text name="rm_rl_migration_message" text="Previous Realistic Livestock data was found in this savegame. Your settings, animal data, Dewars, and AI Straw hand tools will be automatically migrated to Realistic Livestock - RitterMod version when the game saves."/>
+		<text name="rm_rl_migration_files_found" text="Data files found:"/>
+		<text name="rm_rl_migration_continue" text="Continue"/>
+		<text name="rm_rl_migration_quit" text="Quit"/>
+
+
 	</texts>
 </l10n>


### PR DESCRIPTION
Implement  migration from abandoned FS25_RealisticLivestock mod to this version.

Migration:
- Detect old mod conflict and show blocking dialog if both mods enabled
- Detect old save data files (rlSettings.xml, animalSystem.xml, handTools.xml, items.xml)
- Show informational dialog listing files to be migrated
- Automatic migration via dual-read (old/new) and new-save pattern

Fixes #1