### PR TITLE
Maximize pregnancy consumption factor to avoid pregnant PIG overconsumption

### DIFF
--- a/scripts/animal/RealisticLivestock_Animal.lua
+++ b/scripts/animal/RealisticLivestock_Animal.lua
@@ -1348,7 +1348,7 @@ function Animal:updateInput()
             if self.isLactating then litersPerDay = litersPerDay * 1.25 end
 
             if self.reproduction ~= nil and self.reproduction > 0 and self.pregnancy ~= nil and self.pregnancy.pregnancies ~= nil then
-                litersPerDay = litersPerDay * math.pow(1 + ((self.reproduction / 100) / 5), #self.pregnancy.pregnancies)
+                litersPerDay = litersPerDay * math.pow(1 + ((self.reproduction / 100) / 5),  math.min(#self.pregnancy.pregnancies, 3)))
             end
 
             if self.genetics.metabolism ~= nil then litersPerDay = litersPerDay * self.genetics.metabolism end
@@ -1362,7 +1362,7 @@ function Animal:updateInput()
             if self.isLactating then litersPerDay = litersPerDay * 1.5 end
 
             if self.reproduction ~= nil and self.reproduction > 0 and self.pregnancy ~= nil and self.pregnancy.pregnancies ~= nil then
-                litersPerDay = litersPerDay * math.pow(1 + ((self.reproduction / 100) / 5), #self.pregnancy.pregnancies)
+                litersPerDay = litersPerDay * math.pow(1 + ((self.reproduction / 100) / 5),  math.min(#self.pregnancy.pregnancies, 3)))
             end
         end
 

--- a/scripts/animal/RealisticLivestock_Animal.lua
+++ b/scripts/animal/RealisticLivestock_Animal.lua
@@ -1348,7 +1348,7 @@ function Animal:updateInput()
             if self.isLactating then litersPerDay = litersPerDay * 1.25 end
 
             if self.reproduction ~= nil and self.reproduction > 0 and self.pregnancy ~= nil and self.pregnancy.pregnancies ~= nil then
-                litersPerDay = litersPerDay * math.pow(1 + ((self.reproduction / 100) / 5),  math.min(#self.pregnancy.pregnancies, 3)))
+                litersPerDay = litersPerDay * math.pow(1 + ((self.reproduction / 100) / 5),  math.min(#self.pregnancy.pregnancies, 3))
             end
 
             if self.genetics.metabolism ~= nil then litersPerDay = litersPerDay * self.genetics.metabolism end
@@ -1362,7 +1362,7 @@ function Animal:updateInput()
             if self.isLactating then litersPerDay = litersPerDay * 1.5 end
 
             if self.reproduction ~= nil and self.reproduction > 0 and self.pregnancy ~= nil and self.pregnancy.pregnancies ~= nil then
-                litersPerDay = litersPerDay * math.pow(1 + ((self.reproduction / 100) / 5),  math.min(#self.pregnancy.pregnancies, 3)))
+                litersPerDay = litersPerDay * math.pow(1 + ((self.reproduction / 100) / 5),  math.min(#self.pregnancy.pregnancies, 3))
             end
         end
 


### PR DESCRIPTION
Pigs are generally expecting around 12 piglets, with the original calculation:
A pregnant pig which expects 12 piglets and it's around 90% of the reproduction the original calculation would result: 
`(1+(0.9/5))^12 =` **7.28** multiplier
Or in the Reproduction = 50% state: 
`(1+(0.5/5))^12 =` **3.14** multiplier.

I think limiting the exponent to grow to maximum 3, would result way more realistic values, like for the above cases **1.64** or **1.33**. 
These numbers are still a little bit over the realistic values, but should be more player friendly, and shouldn't broke any other animals?

