### PR TITLE
Added rounding to reproduction change calculations instead of math.floor

### DIFF
--- a/scripts/animal/AnimalReproduction.lua
+++ b/scripts/animal/AnimalReproduction.lua
@@ -247,7 +247,7 @@ end
 --- @param animal table Animal instance
 --- @param delta number Amount to change reproduction by
 function AnimalReproduction.changeReproduction(animal, delta)
-    animal.reproduction = math.clamp(math.floor(animal.reproduction + math.max(delta, 1)), 0, 100)
+    animal.reproduction = math.clamp((math.floor((animal.reproduction + math.max(delta, 1)) * 100)/100), 0, 100)
 end
 
 --- Calculate the daily reproduction delta based on gestation duration.
@@ -266,7 +266,7 @@ function AnimalReproduction.getReproductionDelta(animal)
     end
 
     if duration > 0 then
-        return math.floor((100 / duration) / g_currentMission.environment.daysPerPeriod)
+        return math.floor(((100 / duration) / g_currentMission.environment.daysPerPeriod)*100)/100
     end
 
     return 0


### PR DESCRIPTION
With this change, gestation period will be way closer to the ones defined in the animals.xml config file, when playing with higher daysPerPeriod values. 

As an example, we are playing with a dairy farm where the cows gestation period is defined to be 10 months, and the days per period value is 6. 
Without the change, the reproductionDelta would be: math.floor(100/10/6) = **1** , effectively the gestation would be **100 in-game days ( which is 16.67 months).**
With the change, the reproductionDelta is: math.floor((100/10/6)*100)/100 = **1.66**, effectively the gestation would be 60.2 in-game days so way more closer to the 10 month defined value.

Save and load worked with the change, and the reproduction values changed according to my expectations. 
TBH not entirely sure, if rounding is actually necessary, but this should work better then floor. 