### PR TITLE
Fix rabbit reproduction (add supported=true) in HofBergmann v1.3 and v1.4

### DIFF
--- a/mod_support/FS25_HofBergmann/v1.3/animals.xml
+++ b/mod_support/FS25_HofBergmann/v1.3/animals.xml
@@ -161,7 +161,7 @@
 
         <!-- Override: fix RABBIT_MALE reproduction age from default 18 → 6 months -->
         <subType subType="RABBIT_MALE" minWeight="0.1" targetWeight="3.0" maxWeight="5.5">
-            <reproduction minAgeMonth="6"/>
+            <reproduction minAgeMonth="6" supported="true"/>
         </subType>
     </animal>
 

--- a/mod_support/FS25_HofBergmann/v1.4/animals.xml
+++ b/mod_support/FS25_HofBergmann/v1.4/animals.xml
@@ -189,7 +189,7 @@
 
         <!-- Override: fix RABBIT_MALE reproduction age from default 18 → 6 months -->
         <subType subType="RABBIT_MALE" minWeight="0.1" targetWeight="3.0" maxWeight="5.5">
-            <reproduction minAgeMonth="6"/>
+			<reproduction minAgeMonth="6" supported="true"/>
         </subType>
     </animal>
 


### PR DESCRIPTION
The HofBergmann map sets RABBIT_MALE reproduction to supported="false" by 
default. The existing override in mod_support already corrected the 
minAgeMonth (18 → 6), but did not set supported="true", so rabbits never 
actually reproduced despite the age fix.

This adds supported="true" to the RABBIT_MALE reproduction override in 
both v1.3 and v1.4 animals.xml.