### PR TITLE
Fix legacy herdsman profiles loading as defaults

### DIFF
--- a/scripts/herdsman/AIAnimalManager.lua
+++ b/scripts/herdsman/AIAnimalManager.lua
@@ -280,7 +280,7 @@ end
 
 function AIAnimalManager:loadFromXMLFile(xmlFile, baseKey)
 
-	local key = self.isProfile and basekey or (baseKey .. ".AIAnimalManager")
+	local key = self.isProfile and baseKey or (baseKey .. ".AIAnimalManager")
 	local settings = self.settings
 
 


### PR DESCRIPTION
## Summary

- Correct the case-sensitive `baseKey` reference used when loading legacy herdsman profiles.
- Preserve the existing `.AIAnimalManager` subtree for non-profile husbandry data.

## Root cause

Profile settings are saved directly beneath their `profiles.profile(i)` key. During loading, the misspelled `basekey` evaluated to nil, causing Lua's `and/or` expression to fall through to the husbandry-specific `.AIAnimalManager` subtree.

The saved profile therefore appeared to load but contained default settings.

## User impact

Existing legacy herdsman profiles now restore their saved settings instead of silently loading defaults. Non-profile husbandry loading is unchanged.

## Validation

- Exercised profile and husbandry loading with a focused Lua harness covering all 73 XML reads in each mode.
- Confirmed profile reads remain directly beneath `profiles.profile(i)`.
- Confirmed husbandry reads retain the `.AIAnimalManager` suffix.
- Passed Lua syntax validation after normalizing GIANTS-specific language extensions.
- Passed `git diff --check`.
